### PR TITLE
Fix zooping on client

### DIFF
--- a/Zoop/ZoopPatch.cs
+++ b/Zoop/ZoopPatch.cs
@@ -81,8 +81,8 @@ namespace ZoopMod.Zoop {
 		//public static bool CFree = false;
 		[UsedImplicitly]
 		public static bool Prefix(InventoryManager __instance) {
-			if(GameManager.RunSimulation) //not let it work in multiplayer client, as it bring errors there
-			{
+			// if(GameManager.RunSimulation) //not let it work in multiplayer client, as it bring errors there
+			// {
 
 				bool scrollUp = __instance.newScrollData > 0f;
 				bool scrollDown = __instance.newScrollData < 0f;
@@ -148,7 +148,7 @@ namespace ZoopMod.Zoop {
 				}
 
 				return !ZoopUtility.isZoopKeyPressed;
-			} else return true; //let normal building work in multiplayer client too.
+			// } else return true; //let normal building work in multiplayer client too.
 		}
 	}
 

--- a/Zoop/ZoopUtility.cs
+++ b/Zoop/ZoopUtility.cs
@@ -16,7 +16,7 @@ using System.Threading;
 using Assets.Scripts.Objects.Structures;
 using CreativeFreedom;
 using UnityEngine;
-using Object = object; //SOMETHING NEW
+using Object = UnityEngine.Object; //SOMETHING NEW
 
 //using creativefreedom;
 
@@ -436,7 +436,7 @@ namespace ZoopMod.Zoop {
 				DynamicThing occupant2 = inventoryManager.InactiveHand.Slot.Get(); // InventoryManager.IsAuthoringMode ? occupant0 : inventoryManager.InactiveHand.Slot.Occupant;
 																				   // ISSUE: explicit non-virtual call
 				structureMessage.OffhandOccupantReferenceId = occupant2 != null ? occupant2.ReferenceId : 0L;
-				structureMessage.LocalPosition = item.transform.position.ToGrid();
+				structureMessage.LocalPosition = item.transform.position.ToGridPosition();
 				structureMessage.Rotation = item.transform.rotation;
 				structureMessage.CreatorSteamId = (ulong)InventoryManager.ParentBrain.ReferenceId;
 				structureMessage.OptionIndex = buildIndex;


### PR DESCRIPTION
need to use ToGrid instead of ToGridPosition for the proper construction location. this was causing the structures to be built overlapping.

tested on a client with cables, pipes, chutes, and frames