### PR TITLE
fix: skip zoop cells that would merge onto a long straight pipe/cable

### DIFF
--- a/Zoop/Core/ZoopBuildScheduler.cs
+++ b/Zoop/Core/ZoopBuildScheduler.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Assets.Scripts.Inventory;
 using Assets.Scripts.Objects;
+using Assets.Scripts.Util;
 using UnityEngine;
 using ZoopMod.Zoop.Logging;
 using ZoopMod.Zoop.Placement;
@@ -23,6 +24,9 @@ internal sealed class ZoopBuildScheduler
     BindingFlags.NonPublic | BindingFlags.Instance, null,
     [typeof(InventoryManager.DelegateEvent), typeof(float), typeof(Structure)],
     null);
+
+  // Half-extent of the cell probe box, matching the small-grid cell probe the preview barrier scan uses.
+  private static readonly Vector3 CellProbeHalfExtent = Vector3.one * 0.05f;
 
   private readonly ZoopPreviewCoordinator previewCoordinator;
   private readonly IZoopController host;
@@ -149,6 +153,20 @@ internal sealed class ZoopBuildScheduler
     {
       var previewPiece = draft.PreviewPieces[structureIndex];
       var previewStructure = previewPiece.Structure;
+
+      // A zoop cell that lands on an existing long Straight variant of the same family (the 3 / 5 / 10
+      // segment pipe or super-heavy cable pieces) would merge onto it. That merge charges a negative item
+      // cost (the long piece costs more than the single tile that replaces it) and crashes in
+      // Stackable.OnUseItem with a negative RemoveRange count. The interactive cursor blocks the merge;
+      // this build path completes placement directly and skips that check. Drop the cell here so the long
+      // piece is left intact and the rest of the run still builds. See issue #22.
+      if (previewStructure is IGridMergeable && CellHoldsMergeableLongVariant(previewStructure))
+      {
+        ZoopLog.Debug(
+          $"[Build] Skipping {previewStructure.PrefabName} at index {structureIndex}: cell holds a long straight variant that cannot be merged onto.");
+        continue;
+      }
+
       var buildIndex =
         ZoopConstructableResolver.ResolveBuildIndex(draft, inventoryManager, previewStructure, structureIndex);
       if (buildIndex < 0)
@@ -173,6 +191,44 @@ internal sealed class ZoopBuildScheduler
     }
 
     return new ZoopBuildPlan(pieces);
+  }
+
+  // True when an existing world structure at the cursor's cell is a long Straight variant of the same
+  // family (the 3 / 5 / 10 segment pieces). Merging a single tile onto one charges the negative item cost
+  // that crashes the build. Matching the cursor's concrete type keeps a pipe run that merely crosses an
+  // existing cable (the two can share a cell) from being dropped. The preview pieces have their colliders
+  // disabled and the cursor is hidden, so the probe only finds real world structures.
+  private static bool CellHoldsMergeableLongVariant(Structure cursor)
+  {
+    var colliders = Physics.OverlapBox(cursor.transform.position, CellProbeHalfExtent, Quaternion.identity,
+      ~0, QueryTriggerInteraction.Ignore);
+    foreach (var collider in colliders)
+    {
+      var existing = collider.GetComponentInParent<Structure>();
+      if (existing == null || ReferenceEquals(existing, cursor))
+      {
+        continue;
+      }
+
+      if (existing is IGridMergeable &&
+          existing.GetType() == cursor.GetType() &&
+          SpansMultipleCells(existing))
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  // A long Straight variant occupies more than one small-grid cell; a single tile occupies one. The
+  // connection type does not separate them for every family (the long super-heavy cables report Straight,
+  // not StraightAsymmetric), but the footprint always does.
+  private static bool SpansMultipleCells(Structure structure)
+  {
+    var cells = structure.GridBounds.GetLocalSmallGrid(structure.ThingTransformPosition,
+      structure.ThingTransformRotation);
+    return cells is System.Array array && array.Length > 1;
   }
 
   public void CancelPendingBuild()
@@ -310,14 +366,13 @@ internal sealed class ZoopBuildScheduler
     try
     {
       yield return ZoopBuildExecutor.BuildAll(inventoryManager, buildPlan);
+      ZoopLog.Debug($"[Build] Zoop build completed for {buildPlan.Count} piece(s); canceling placement cursor.");
     }
     finally
     {
       ClearBuildExecutionState();
+      inventoryManager.CancelPlacement();
     }
-
-    ZoopLog.Debug($"[Build] Zoop build completed for {buildPlan.Count} piece(s); canceling placement cursor.");
-    inventoryManager.CancelPlacement();
   }
 
   private static Assets.Scripts.ICreativeSpawnable ResolveSpawnPrefabForBuild(ZoopDraft draft,


### PR DESCRIPTION
Fixes #22.

## The crash

Dragging a pipe or cable run over an existing "long" straight variant (the 3, 5, and 10 segment pieces) throws an unhandled `ArgumentOutOfRangeException` and aborts the placement:

```
ArgumentOutOfRangeException: ... count
  System.Collections.Generic.List`1[T].RemoveRange
  Assets.Scripts.Objects.Items.Stackable.OnUseItem
  Assets.Scripts.Objects.MultiConstructor.Construct
  Assets.Scripts.Objects.MultiMergeConstructor.Construct
  OnServer.UseMultiConstructor
  ...
  ZoopMod.Zoop.Placement.ZoopBuildExecutor+<BuildAll>d__4.MoveNext
```

## Cause

`ZoopBuildExecutor.BuildAll` completes each cell by invoking the private `InventoryManager.UsePrimaryComplete` directly. The interactive cursor only reaches that call after `CanConstruct()` / `CanReplace()` pass, and those are what refuse a merge onto a long variant; `UsePrimaryComplete` itself does no validation. When a zoop cell lands on a long variant, `MultiMergeConstructor.Construct` charges a negative item cost (the long piece's build cost minus the single tile that replaces it, e.g. `1 - 3 = -2`) and passes it to `Stackable.OnUseItem`, which calls `List.RemoveRange` with a negative count.

The preview validator (`ZoopPreviewValidator`) does run the full check and abandons the whole zoop if a cell fails, so this does not bite in ordinary play. It still reaches the build when that preview check is skipped: most clearly with CreativeFreedom present (`ZoopPreviewLayoutCoordinator.HasSmallGridCellError` returns no-error while it is), but also when a long piece is already in the world and the build path completes a cell over it. The build loop has no legality re-check of its own.

## The fix

Re-check each cell when the build plan is captured, and drop any cell that sits on an existing long variant of the same family. The long piece is left intact and the rest of the run still builds.

- `ZoopBuildScheduler.CaptureBuildPlan` probes each planned cell (the same `Physics.OverlapBox` the barrier scan already uses) and skips it when an existing structure of the cursor's own concrete type occupies more than one small-grid cell.
- Detection is by footprint, not connection type. The long super-heavy cables report `GetConnectionType() == Straight` at runtime (not `StraightAsymmetric` as the long pipes and chutes do), and the merge block lives in `Cable._IsCollision` for cables but in `Piping.CanReplace` for pipes, so neither the connection type nor a single `CanReplace` check is reliable across both families. The footprint cell count is.
- Matching the cursor's concrete type leaves a pipe run that merely crosses an existing cable (the two can share a cell) untouched. Chutes never reach the merge path (`Chute` is not `IGridMergeable`), so they are unaffected.

It also moves `inventoryManager.CancelPlacement()` into the `finally` in `ExecuteBuildPlan`, so a build-time exception can no longer leave the placement cursor stuck.

## Scope

Covers the reported case: a zoop completing a cell over a long variant already in the world. Legal single-tile merges and a run that crosses a different family are unchanged.

## Testing

Built against game `0.2.6228.27061`. On a live dedicated server the long variants read a footprint of more than one cell with build cost 3 / 4 / 7 / 8, versus 1 for a single tile, and merging a single tile onto one computes the negative cost (`num4 = 1 - 3 = -2` for the 3-segment piece, more negative for the 5- and 10-segment variants). Before the change, a zoop across a placed long pipe or cable crashes; after it, the run builds around the long piece and the log shows a `[Build] Skipping ...` line for the dropped cell.

The diff is one file plus the `finally` move; happy to adjust naming or placement to fit the codebase.
